### PR TITLE
Move to modules to better isolate the code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.js]
+indent_size = 4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# FruitFly
+
+## Development
+
+To simplify development you can run a simple HTTP server using python:
+
+```sh
+python3 -m http.server
+```

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 
 <head>
@@ -18,7 +19,8 @@
             </div>
             <div class="col col-lg-7">
                 <h1>Fruitfly</h1>
-                <i>Created by Alexandros de Regt 2023, See <a href="https://github.com/AdeRegt/Fruitfly">Github</a> for the sourcecode</i><br/>
+                <i>Created by Alexandros de Regt 2023, See <a href="https://github.com/AdeRegt/Fruitfly">Github</a> for
+                    the sourcecode</i><br />
             </div>
         </div>
         <div class="row" style="height: calc(100% - 250px);">
@@ -39,7 +41,7 @@
                 </textarea>
                 <br />
                 <br />
-                <label id="mylabel" style="color:red"></label>
+                <label id="errorContainer" style="color:red"></label>
                 <a id="downloadlink" type="button" class="btn btn-info disabled">Download assembled file</a>
                 <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#opcodeModal">Show
                     opcode list</button>
@@ -71,7 +73,7 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <b>Instructionset</b><br/>
+                    <b>Instructionset</b><br />
                     <table class="table">
                         <thead>
                             <tr>
@@ -85,34 +87,37 @@
                             <tr>
                                 <th scope="row">EXIT [EXITCODE]</th>
                                 <td>Exit the emulation</td>
-                                <td>Exits the virtual machine with EXITCODE as exitcode. EXITCODE should be a number</td>
+                                <td>Exits the virtual machine with EXITCODE as exitcode. EXITCODE should be a number
+                                </td>
                                 <td><code>EXIT 5</code></td>
                             </tr>
                             <tr>
                                 <th scope="row">DEBUG</th>
                                 <td>Debug</td>
-                                <td>Stops emulator and shows status of registers, Instruction Pointer and the callstack</td>
+                                <td>Stops emulator and shows status of registers, Instruction Pointer and the callstack
+                                </td>
                                 <td><code>DEBUG</code></td>
                             </tr>
                             <tr>
                                 <th scope="row">SYSCALL [SYMBOL]</th>
                                 <td>Syscall</td>
-                                <td>Preform a syscall using the structure defined at SYMBOL. Click <a href="#syscaltable">HERE</a> to see which commands are supported</td>
+                                <td>Preform a syscall using the structure defined at SYMBOL. Click <a
+                                        href="#syscaltable">HERE</a> to see which commands are supported</td>
                                 <td>
-                                    Move the address of teststring to register A<br/>
-                                    <code>A2RA teststring</code> <br/><br/>
-                                    Move the address in register A to the string_i_want_to_print variable<br/>
-                                    <code>RA2A string_i_want_to_print</code> <br/><br/>
-                                    Call the systemcall<br/>
-                                    <code>SYSCALL structure_of_print_command</code> <br/><br/>
-                                    Return to the previous operation<br/>
-                                    <code>RETURN</code><br/><br/>
-                                    Structure of the systemcall<br/>
-                                    <code>structure_of_print_command:</code> <br/><br/>
-                                    Fill the structure with the opcode of the print command: 1 <br/>
-                                    <code>DUMP 0x0001</code> <br/><br/>
-                                    The string we want to print<br/>
-                                    <code>DUMP "Hello world!\n\0"</code> <br/><br/>
+                                    Move the address of teststring to register A<br />
+                                    <code>A2RA teststring</code> <br /><br />
+                                    Move the address in register A to the string_i_want_to_print variable<br />
+                                    <code>RA2A string_i_want_to_print</code> <br /><br />
+                                    Call the systemcall<br />
+                                    <code>SYSCALL structure_of_print_command</code> <br /><br />
+                                    Return to the previous operation<br />
+                                    <code>RETURN</code><br /><br />
+                                    Structure of the systemcall<br />
+                                    <code>structure_of_print_command:</code> <br /><br />
+                                    Fill the structure with the opcode of the print command: 1 <br />
+                                    <code>DUMP 0x0001</code> <br /><br />
+                                    The string we want to print<br />
+                                    <code>DUMP "Hello world!\n\0"</code> <br /><br />
                                 </td>
                             </tr>
                             <tr>
@@ -196,7 +201,7 @@
                             <tr>
                                 <th scope="row">JL [SYMBOL]</th>
                                 <td>Jump less</td>
-                                <td>Goto symbol if A<B</td>
+                                <td>Goto symbol if A<B< /td>
                                 <td><code>JL location</code></td>
                             </tr>
                             <tr>
@@ -213,8 +218,8 @@
                             </tr>
                         </tbody>
                     </table>
-                    <br/>
-                    <b id="syscaltable">Functions</b><br/>
+                    <br />
+                    <b id="syscaltable">Functions</b><br />
                     <table class="table">
                         <thead>
                             <tr>
@@ -227,8 +232,8 @@
                             <tr>
                                 <th scope="row">Print</th>
                                 <td>
-                                    code: 1<br/>
-                                    link: location<br/>
+                                    code: 1<br />
+                                    link: location<br />
                                 </td>
                                 <td>raw output something</td>
                             </tr>
@@ -242,33 +247,7 @@
         </div>
     </div>
 
-    <script src="/js/compiler.js"></script>
-    <script src="/js/emulator.js"></script>
-    <script>
-
-        window.fruitflysession = new FruitflyCompilerEditor(document.getElementById("thing"), document.getElementById("mylabel"), document.getElementById("downloadlink"));
-        window.fruitflysession.attach();
-        window.fruitflysession.setOnCompiledListener(function (data) {
-            window.fruitflyemulator.insertCardridge(data);
-        });
-
-        window.fruitflyemulator = new FruitflyEmulator(document.getElementById("canvasid"), document.getElementById("mystatus"));
-        document.getElementById("inputGroupFileAddon03").addEventListener("click", function () {
-            window.fruitflyemulator.insertCardridge(window.fruitflysession.generateUint16DataArray());
-        });
-        document.getElementById("inputGroupFile03").addEventListener("change", function (evt) {
-            var file = evt.target.files[0];
-            let reader = new FileReader();
-            reader.addEventListener("loadend", function (e) {
-                var data = new Uint16Array(e.target.result);
-                window.fruitflyemulator.insertCardridge(data);
-            });
-            reader.readAsArrayBuffer(file);
-        });
-
-        window.fruitflysession.fire();
-
-    </script>
+    <script src="./js/editor.js" type="module"></script>
 </body>
 
 </html>

--- a/js/compiler.js
+++ b/js/compiler.js
@@ -104,7 +104,7 @@ class FruitflyCompilerToken {
     }
 }
 
-class FruitflyCompiler {
+export class FruitflyCompiler {
 
     constructor() { }
 
@@ -511,51 +511,4 @@ class FruitflyCompiler {
         return this.errorslist;
     }
 
-}
-
-class FruitflyCompilerEditor extends FruitflyCompiler {
-
-    constructor(textarea, messagearea, downloadlink) {
-        super();
-        this.textarea = textarea;
-        this.messagearea = messagearea;
-        this.downloadlink = downloadlink;
-        this.oncompiled = null;
-    }
-
-    getEditorsContent() {
-        return this.textarea.value.trim();
-    }
-
-    setMessage(message) {
-        this.messagearea.innerHTML = message;
-    }
-
-    setOnCompiledListener(fun){
-        this.oncompiled = fun;
-    }
-
-    fire(){
-        this.textarea.dispatchEvent(new Event("keyup"));
-    }
-
-    attach() {
-        var innerthis = this;
-        this.textarea.addEventListener("keyup", function (evt) {
-            var sourcecode = innerthis.getEditorsContent();
-            innerthis.setSource(sourcecode);
-            var res = innerthis.compile();
-            innerthis.setMessage(innerthis.getErrors().join("<br/>"));
-            if (res !== false) {
-                innerthis.downloadlink.href = res;
-                innerthis.downloadlink.download = "test.sxe";
-                innerthis.downloadlink.classList.remove("disabled");
-                if(innerthis.oncompiled!=null){
-                    innerthis.oncompiled(innerthis.generateUint16DataArray());
-                }
-            }else{
-                innerthis.downloadlink.classList.add("disabled");
-            }
-        });
-    }
 }

--- a/js/editor.js
+++ b/js/editor.js
@@ -1,0 +1,84 @@
+import { FruitflyEmulator } from "./emulator.js";
+import { FruitflyCompiler } from "./compiler.js";
+
+class FruitflyCompilerEditor {
+    emulator = new FruitflyCompiler();
+
+    onCompiled = () => null;
+
+    constructor(textarea, errorContainerEl, downloadLink) {
+        this.textarea = textarea;
+        this.errorContainerEl = errorContainerEl;
+        this.downloadLink = downloadLink;
+    }
+
+    getEditorsContent() {
+        return this.textarea.value.trim();
+    }
+
+    setMessage(message) {
+        this.errorContainerEl.innerHTML = message;
+    }
+
+    setOnCompiledListener(fun) {
+        this.onCompiled = fun;
+    }
+
+    fire() {
+        this.textarea.dispatchEvent(new Event("keyup"));
+    }
+
+    attach() {
+        this.textarea.addEventListener("keyup", () => {
+            const sourceCode = this.getEditorsContent();
+            this.emulator.setSource(sourceCode);
+
+            const res = this.emulator.compile();
+            this.setMessage(this.emulator.getErrors().join("<br/>"));
+
+            // when the program is invalid we block the download button
+            if (res === false) {
+                this.downloadLink.classList.add("disabled");
+                return;
+            }
+
+            this.downloadLink.href = res;
+            this.downloadLink.download = "test.sxe";
+            this.downloadLink.classList.remove("disabled");
+            this.onCompiled(this.emulator.generateUint16DataArray());
+        });
+    }
+}
+
+const editor = new FruitflyCompilerEditor(
+    document.getElementById("thing"),
+    document.getElementById("errorContainer"),
+    document.getElementById("downloadlink")
+);
+editor.attach();
+editor.setOnCompiledListener(function (data) {
+    emulator.insertCartridge(data);
+});
+
+const emulator = new FruitflyEmulator(
+    document.getElementById("canvasid"),
+    document.getElementById("mystatus")
+);
+document
+    .getElementById("inputGroupFileAddon03")
+    .addEventListener("click", function () {
+        emulator.insertCartridge(editor.generateUint16DataArray());
+    });
+document
+    .getElementById("inputGroupFile03")
+    .addEventListener("change", function (evt) {
+        var file = evt.target.files[0];
+        let reader = new FileReader();
+        reader.addEventListener("loadend", function (e) {
+            var data = new Uint16Array(e.target.result);
+            emulator.insertCartridge(data);
+        });
+        reader.readAsArrayBuffer(file);
+    });
+
+editor.fire();

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -1,5 +1,4 @@
-class FruitflyEmulator {
-
+export class FruitflyEmulator {
     constructor(canvas, status) {
         this.rawcanvas = canvas;
         this.rawstatus = status;
@@ -34,7 +33,26 @@ class FruitflyEmulator {
 
     tick() {
         this.tickssinceboot++;
-        this.setStatus("IP = 0x" + this.instruction_pointer.toString(16) + " | A = 0x" + this.registerA.toString(16) + " | B = 0x" + this.registerB.toString(16) + " | Opcode = 0x" + this.current_opcode.toString(16) + " | Argument = 0x" + this.current_argument.toString(16) + " | Stack = " + this.callstack.join(",") + " | LastError=" + this.lasterror + " | IsRunning=" + this.is_running + " | Ticks=" + this.tickssinceboot);
+        this.setStatus(
+            "IP = 0x" +
+                this.instruction_pointer.toString(16) +
+                " | A = 0x" +
+                this.registerA.toString(16) +
+                " | B = 0x" +
+                this.registerB.toString(16) +
+                " | Opcode = 0x" +
+                this.current_opcode.toString(16) +
+                " | Argument = 0x" +
+                this.current_argument.toString(16) +
+                " | Stack = " +
+                this.callstack.join(",") +
+                " | LastError=" +
+                this.lasterror +
+                " | IsRunning=" +
+                this.is_running +
+                " | Ticks=" +
+                this.tickssinceboot
+        );
         if (!this.is_running) {
             return;
         }
@@ -42,63 +60,74 @@ class FruitflyEmulator {
             return;
         }
         this.current_opcode_set = this.memory[this.instruction_pointer];
-        this.current_opcode = (this.current_opcode_set & 0xF000) >> 12;
-        this.current_argument = (this.current_opcode_set & 0x0FFF);
-        if (this.current_opcode == 0xF) { // EXIT 
+        this.current_opcode = (this.current_opcode_set & 0xf000) >> 12;
+        this.current_argument = this.current_opcode_set & 0x0fff;
+        if (this.current_opcode == 0xf) {
+            // EXIT
             this.is_running = false;
             if (this.onexit != null) {
                 this.onexit(this.current_argument);
             }
-        } else if (this.current_opcode == 0xE) { // DEBUG
+        } else if (this.current_opcode == 0xe) {
+            // DEBUG
             window.alert(this.getStatus());
             this.instruction_pointer++;
-        } else if (this.current_opcode == 0xD) { // SYSTEMCALL
+        } else if (this.current_opcode == 0xd) {
+            // SYSTEMCALL
             var syscallid = this.memory[this.current_argument];
-            if(syscallid==1){
+            if (syscallid == 1) {
                 var i = 1;
                 var str = "";
-                while(true){
-                    var g = this.memory[this.current_argument+i];
-                    var low = g & 0x00FF;
-                    var high = (g & 0xFF00)/0x100;
-                    if(low==0){
+                while (true) {
+                    var g = this.memory[this.current_argument + i];
+                    var low = g & 0x00ff;
+                    var high = (g & 0xff00) / 0x100;
+                    if (low == 0) {
                         break;
                     }
-                    str += ""+String.fromCharCode(low);
-                    if(high==0){
+                    str += "" + String.fromCharCode(low);
+                    if (high == 0) {
                         break;
                     }
-                    str += ""+String.fromCharCode(high);
+                    str += "" + String.fromCharCode(high);
                     i++;
                 }
                 this.rawcanvas.append(str);
-            }else{
+            } else {
                 this.is_running = false;
                 this.lasterror = "This systemcall is not supported yet";
                 return;
             }
             this.instruction_pointer++;
-        } else if (this.current_opcode == 0xC) { // RETURN
+        } else if (this.current_opcode == 0xc) {
+            // RETURN
             this.instruction_pointer = this.callstack.pop();
-        } else if (this.current_opcode == 0xB) { // CALL
+        } else if (this.current_opcode == 0xb) {
+            // CALL
             this.callstack.push(this.instruction_pointer + 1);
             this.instruction_pointer = this.current_argument;
-        } else if (this.current_opcode == 0xA) { // A2RA
+        } else if (this.current_opcode == 0xa) {
+            // A2RA
             this.A = this.memory[this.current_argument];
             this.instruction_pointer++;
-        } else if (this.current_opcode == 0x9) { // A2RB
+        } else if (this.current_opcode == 0x9) {
+            // A2RB
             this.B = this.memory[this.current_argument];
             this.instruction_pointer++;
-        } else if (this.current_opcode == 0x8) { // RA2A
+        } else if (this.current_opcode == 0x8) {
+            // RA2A
             this.memory[this.current_argument] = this.A;
             this.instruction_pointer++;
-        } else if (this.current_opcode == 0x7) { // RB2A
+        } else if (this.current_opcode == 0x7) {
+            // RB2A
             this.memory[this.current_argument] = this.B;
             this.instruction_pointer++;
-        } else if (this.current_opcode == 0x6) { // JUMP
+        } else if (this.current_opcode == 0x6) {
+            // JUMP
             this.instruction_pointer = this.current_argument;
             this.instruction_pointer++;
-        } else if (this.current_opcode == 0x5) { // MATH
+        } else if (this.current_opcode == 0x5) {
+            // MATH
             if (this.current_argument == 1) {
                 this.A += this.B;
             }
@@ -112,28 +141,32 @@ class FruitflyEmulator {
                 this.A *= this.B;
             }
             this.instruction_pointer++;
-        } else if (this.current_opcode == 0x4) { // JE
-            if (this.A == this.B) { 
-                this.instruction_pointer = this.current_argument; 
-            }else{
+        } else if (this.current_opcode == 0x4) {
+            // JE
+            if (this.A == this.B) {
+                this.instruction_pointer = this.current_argument;
+            } else {
                 this.instruction_pointer++;
             }
-        } else if (this.current_opcode == 0x3) { // JM
-            if (this.A > this.B) { 
-                this.instruction_pointer = this.current_argument; 
-            }else{
+        } else if (this.current_opcode == 0x3) {
+            // JM
+            if (this.A > this.B) {
+                this.instruction_pointer = this.current_argument;
+            } else {
                 this.instruction_pointer++;
             }
-        } else if (this.current_opcode == 0x2) { // JL
-            if (this.A < this.B) { 
-                this.instruction_pointer = this.current_argument; 
-            }else{
+        } else if (this.current_opcode == 0x2) {
+            // JL
+            if (this.A < this.B) {
+                this.instruction_pointer = this.current_argument;
+            } else {
                 this.instruction_pointer++;
             }
-        } else if (this.current_opcode == 0x1) { // JNE
-            if (this.A != this.B) { 
-                this.instruction_pointer = this.current_argument; 
-            }else{
+        } else if (this.current_opcode == 0x1) {
+            // JNE
+            if (this.A != this.B) {
+                this.instruction_pointer = this.current_argument;
+            } else {
                 this.instruction_pointer++;
             }
         } else {
@@ -142,15 +175,18 @@ class FruitflyEmulator {
         }
     }
 
-    insertCardridge(dataset) {
+    insertCartridge(dataset) {
         // check size of the cardridge
         if (dataset.length != 4103) {
-            window.alert("Invalid cardridge. Expected size 4103 but found " + dataset.length);
+            window.alert(
+                "Invalid cardridge. Expected size 4103 but found " +
+                    dataset.length
+            );
             return;
         }
         // check signature
         // SIGNATURE
-        if (!(dataset[0] == 0x5853 && dataset[1] == 0xCD45)) {
+        if (!(dataset[0] == 0x5853 && dataset[1] == 0xcd45)) {
             window.alert("Invalid signature");
             return;
         }
@@ -167,7 +203,8 @@ class FruitflyEmulator {
         this.callstack = [];
         this.lasterror = null;
         this.tickssinceboot = 0;
-        this.rawcanvas.innerHTML = "Application is running since "+(new Date()).toISOString()+"\n";
+        this.rawcanvas.innerHTML =
+            "Application is running since " + new Date().toISOString() + "\n";
         this.is_running = true;
     }
 }


### PR DESCRIPTION
Move the JavaScript code into modules to better isolate the code. This way we don't pollute the window object.

Eventually, if we need to expose the instances to do some kind of debug, we can make use of a flag to expose it conditionally.

**Note:** I usually use VS Code most of the time, so it formatters the code automatically, if you'd like, I can try to save it without changing the rest of the code.