### PR TITLE
Extract opcodes into a separated structure

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -2,7 +2,7 @@ import { FruitflyEmulator } from "./emulator.js";
 import { FruitflyCompiler } from "./compiler.js";
 
 class FruitflyCompilerEditor {
-    emulator = new FruitflyCompiler();
+    compiler = new FruitflyCompiler();
 
     onCompiled = () => null;
 
@@ -31,10 +31,10 @@ class FruitflyCompilerEditor {
     attach() {
         this.textarea.addEventListener("keyup", () => {
             const sourceCode = this.getEditorsContent();
-            this.emulator.setSource(sourceCode);
+            this.compiler.setSource(sourceCode);
 
-            const res = this.emulator.compile();
-            this.setMessage(this.emulator.getErrors().join("<br/>"));
+            const res = this.compiler.compile();
+            this.setMessage(this.compiler.getErrors().join("<br/>"));
 
             // when the program is invalid we block the download button
             if (res === false) {
@@ -45,7 +45,7 @@ class FruitflyCompilerEditor {
             this.downloadLink.href = res;
             this.downloadLink.download = "test.sxe";
             this.downloadLink.classList.remove("disabled");
-            this.onCompiled(this.emulator.generateUint16DataArray());
+            this.onCompiled(this.compiler.generateUint16DataArray());
         });
     }
 }
@@ -67,7 +67,7 @@ const emulator = new FruitflyEmulator(
 document
     .getElementById("inputGroupFileAddon03")
     .addEventListener("click", function () {
-        emulator.insertCartridge(editor.generateUint16DataArray());
+        emulator.insertCartridge(editor.compiler.generateUint16DataArray());
     });
 document
     .getElementById("inputGroupFile03")

--- a/js/emulator.js
+++ b/js/emulator.js
@@ -1,4 +1,25 @@
+import { opcodes } from "./opcodes.js";
+
 export class FruitflyEmulator {
+    operations = {
+        [opcodes.NOP]: this.doNop,
+        [opcodes.JNE]: this.doJNE,
+        [opcodes.JL]: this.doJL,
+        [opcodes.JM]: this.doJM,
+        [opcodes.JE]: this.doJE,
+        [opcodes.FLAGS]: this.doMath,
+        [opcodes.JUMP]: this.doJump,
+        [opcodes.RB2A]: this.doRB2A,
+        [opcodes.RA2A]: this.doRA2A,
+        [opcodes.A2RB]: this.doA2RB,
+        [opcodes.A2RA]: this.doA2RA,
+        [opcodes.CALL]: this.doCall,
+        [opcodes.RETURN]: this.doReturn,
+        [opcodes.SYSCALL]: this.doSystemCall,
+        [opcodes.DEBUG]: this.doDebug,
+        [opcodes.EXIT]: this.doExit,
+    };
+
     constructor(canvas, status) {
         this.rawcanvas = canvas;
         this.rawstatus = status;
@@ -10,13 +31,10 @@ export class FruitflyEmulator {
         this.current_opcode = 0;
         this.current_argument = 0;
         this.is_running = false;
-        this.lasterror = null;
+        this.lastError = null;
         this.onexit = null;
-        this.tickssinceboot = 0;
-        var innerthis = this;
-        this.timer = window.setInterval(function () {
-            innerthis.tick();
-        }, 1);
+        this.ticksSinceBoot = 0;
+        this.timer = null;
     }
 
     setStatus(message) {
@@ -31,8 +49,11 @@ export class FruitflyEmulator {
         this.onexit = fun;
     }
 
-    tick() {
-        this.tickssinceboot++;
+    /**
+     * TODO: possibly it would be great to move all the visual logic out of the module.
+     * The idea is by doing that the emulator can be easily ported, for example to run on Node or Deno.
+     */
+    updateStatus() {
         this.setStatus(
             "IP = 0x" +
                 this.instruction_pointer.toString(16) +
@@ -47,132 +68,167 @@ export class FruitflyEmulator {
                 " | Stack = " +
                 this.callstack.join(",") +
                 " | LastError=" +
-                this.lasterror +
+                this.lastError +
                 " | IsRunning=" +
                 this.is_running +
                 " | Ticks=" +
-                this.tickssinceboot
+                this.ticksSinceBoot
         );
+    }
+
+    stop() {
+        this.is_running = false;
+        clearInterval(this.timer);
+    }
+
+    tick() {
+        this.ticksSinceBoot++;
+        this.updateStatus();
+
         if (!this.is_running) {
             return;
         }
-        if (this.memory[0] == 0) {
+
+        if (this.memory[0] === 0) {
             return;
         }
+
         this.current_opcode_set = this.memory[this.instruction_pointer];
         this.current_opcode = (this.current_opcode_set & 0xf000) >> 12;
         this.current_argument = this.current_opcode_set & 0x0fff;
-        if (this.current_opcode == 0xf) {
-            // EXIT
-            this.is_running = false;
-            clearInterval(this.timer);
-            if (this.onexit != null) {
-                this.onexit(this.current_argument);
-            }
-        } else if (this.current_opcode == 0xe) {
-            // DEBUG
-            window.alert(this.getStatus());
-            this.instruction_pointer++;
-        } else if (this.current_opcode == 0xd) {
-            // SYSTEMCALL
-            var syscallid = this.memory[this.current_argument];
-            if (syscallid == 1) {
-                var i = 1;
-                var str = "";
-                while (true) {
-                    var g = this.memory[this.current_argument + i];
-                    var low = g & 0x00ff;
-                    var high = (g & 0xff00) / 0x100;
-                    if (low == 0) {
-                        break;
-                    }
-                    str += "" + String.fromCharCode(low);
-                    if (high == 0) {
-                        break;
-                    }
-                    str += "" + String.fromCharCode(high);
-                    i++;
+
+        if (!this.operations[this.current_opcode]) {
+            this.lastError = `Unknown opcode: ${this.current_opcode}`;
+            this.stop();
+        }
+
+        this.operations[this.current_opcode].call(this);
+    }
+
+    doExit() {
+        this.stop();
+
+        if (this.onexit != null) {
+            this.onexit(this.current_argument);
+        }
+    }
+
+    doNop() {
+        this.instruction_pointer++;
+    }
+
+    doDebug() {
+        window.alert(this.getStatus());
+        this.instruction_pointer++;
+    }
+
+    doSystemCall() {
+        var syscallid = this.memory[this.current_argument];
+        if (syscallid == 1) {
+            var i = 1;
+            var str = "";
+            while (true) {
+                var g = this.memory[this.current_argument + i];
+                var low = g & 0x00ff;
+                var high = (g & 0xff00) / 0x100;
+                if (low == 0) {
+                    break;
                 }
-                this.rawcanvas.append(str);
-            } else {
-                this.is_running = false;
-                this.lasterror = "This systemcall is not supported yet";
-                return;
+                str += "" + String.fromCharCode(low);
+                if (high == 0) {
+                    break;
+                }
+                str += "" + String.fromCharCode(high);
+                i++;
             }
-            this.instruction_pointer++;
-        } else if (this.current_opcode == 0xc) {
-            // RETURN
-            this.instruction_pointer = this.callstack.pop();
-        } else if (this.current_opcode == 0xb) {
-            // CALL
-            this.callstack.push(this.instruction_pointer + 1);
-            this.instruction_pointer = this.current_argument;
-        } else if (this.current_opcode == 0xa) {
-            // A2RA
-            this.A = this.memory[this.current_argument];
-            this.instruction_pointer++;
-        } else if (this.current_opcode == 0x9) {
-            // A2RB
-            this.B = this.memory[this.current_argument];
-            this.instruction_pointer++;
-        } else if (this.current_opcode == 0x8) {
-            // RA2A
-            this.memory[this.current_argument] = this.A;
-            this.instruction_pointer++;
-        } else if (this.current_opcode == 0x7) {
-            // RB2A
-            this.memory[this.current_argument] = this.B;
-            this.instruction_pointer++;
-        } else if (this.current_opcode == 0x6) {
-            // JUMP
-            this.instruction_pointer = this.current_argument;
-            this.instruction_pointer++;
-        } else if (this.current_opcode == 0x5) {
-            // MATH
-            if (this.current_argument == 1) {
-                this.A += this.B;
-            }
-            if (this.current_argument == 2) {
-                this.A -= this.B;
-            }
-            if (this.current_argument == 3) {
-                this.A /= this.B;
-            }
-            if (this.current_argument == 4) {
-                this.A *= this.B;
-            }
-            this.instruction_pointer++;
-        } else if (this.current_opcode == 0x4) {
-            // JE
-            if (this.A == this.B) {
-                this.instruction_pointer = this.current_argument;
-            } else {
-                this.instruction_pointer++;
-            }
-        } else if (this.current_opcode == 0x3) {
-            // JM
-            if (this.A > this.B) {
-                this.instruction_pointer = this.current_argument;
-            } else {
-                this.instruction_pointer++;
-            }
-        } else if (this.current_opcode == 0x2) {
-            // JL
-            if (this.A < this.B) {
-                this.instruction_pointer = this.current_argument;
-            } else {
-                this.instruction_pointer++;
-            }
-        } else if (this.current_opcode == 0x1) {
-            // JNE
-            if (this.A != this.B) {
-                this.instruction_pointer = this.current_argument;
-            } else {
-                this.instruction_pointer++;
-            }
+            this.rawcanvas.append(str);
         } else {
-            this.is_running = false;
-            this.lasterror = "Unknown opcode";
+            this.lastError = "This systemcall is not supported yet";
+            this.stop();
+            return;
+        }
+        this.instruction_pointer++;
+    }
+
+    doReturn() {
+        this.instruction_pointer = this.callstack.pop();
+    }
+
+    doCall() {
+        this.callstack.push(this.instruction_pointer + 1);
+        this.instruction_pointer = this.current_argument;
+    }
+
+    doA2RA() {
+        this.A = this.memory[this.current_argument];
+        this.instruction_pointer++;
+    }
+
+    doA2RB() {
+        this.B = this.memory[this.current_argument];
+        this.instruction_pointer++;
+    }
+
+    doRA2A() {
+        this.memory[this.current_argument] = this.A;
+        this.instruction_pointer++;
+    }
+
+    doRB2A() {
+        this.memory[this.current_argument] = this.B;
+        this.instruction_pointer++;
+    }
+
+    doJump() {
+        this.instruction_pointer = this.current_argument;
+        this.instruction_pointer++;
+    }
+
+    doMath() {
+        if (this.current_argument == 1) {
+            this.A += this.B;
+        }
+        if (this.current_argument == 2) {
+            this.A -= this.B;
+        }
+        if (this.current_argument == 3) {
+            this.A /= this.B;
+        }
+        if (this.current_argument == 4) {
+            this.A *= this.B;
+        }
+        this.instruction_pointer++;
+    }
+
+    doJE() {
+        if (this.A == this.B) {
+            this.instruction_pointer = this.current_argument;
+        } else {
+            this.instruction_pointer++;
+        }
+    }
+
+    doJM() {
+        if (this.A > this.B) {
+            this.instruction_pointer = this.current_argument;
+        } else {
+            this.instruction_pointer++;
+        }
+    }
+
+    doJL() {
+        if (this.A < this.B) {
+            this.instruction_pointer = this.current_argument;
+        } else {
+            this.instruction_pointer++;
+        }
+    }
+
+    doJNE() {
+        if (this.A != this.B) {
+            this.instruction_pointer = this.current_argument;
+        } else {
+            this.instruction_pointer++;
         }
     }
 
@@ -202,10 +258,11 @@ export class FruitflyEmulator {
         this.registerA = 0;
         this.registerB = 0;
         this.callstack = [];
-        this.lasterror = null;
-        this.tickssinceboot = 0;
+        this.lastError = null;
+        this.ticksSinceBoot = 0;
         this.rawcanvas.innerHTML =
             "Application is running since " + new Date().toISOString() + "\n";
         this.is_running = true;
+        this.timer = window.setInterval(this.tick.bind(this), 1);
     }
 }

--- a/js/opcodes.js
+++ b/js/opcodes.js
@@ -1,0 +1,21 @@
+/**
+ * List of available opcodes.
+ */
+export const opcodes = {
+    NOP: 0x0,
+    JNE: 0x1,
+    JL: 0x2,
+    JM: 0x3,
+    JE: 0x4,
+    FLAGS: 0x5,
+    JUMP: 0x6,
+    RB2A: 0x7,
+    RA2A: 0x8,
+    A2RB: 0x9,
+    A2RA: 0xa,
+    CALL: 0xb,
+    RETURN: 0xc,
+    SYSCALL: 0xd,
+    DEBUG: 0xe,
+    EXIT: 0xf,
+};


### PR DESCRIPTION
With this structure it will be possible to share logic between the compiler and emulator.

Also, the code becomes simpler since we work with the opcode name instead of the hex code.

As future work, we can do the same with the compiler.